### PR TITLE
issue-7: Type 'TIMESTAMP(3) WITH LOCAL TIME ZONE' not recognized

### DIFF
--- a/decodable/client/types.py
+++ b/decodable/client/types.py
@@ -583,12 +583,18 @@ class TimestampLocal(TimestampType):
 
     @classmethod
     def from_str(cls, type: str) -> Optional[FieldType]:
-        found = re.fullmatch(r"TIMESTAMP_LTZ\((?P<precision>\d+)\)", type)
+        found_shorthand = re.fullmatch(r"TIMESTAMP_LTZ\((?P<precision>\d+)\)", type)
+        found_full_version = re.fullmatch(
+            r"TIMESTAMP\((?P<precision>\d+)\) WITH LOCAL TIME ZONE", type
+        )
 
-        if not found:
-            return None
+        if found_shorthand:
+            return cls(int(found_shorthand["precision"]))
 
-        return cls(int(found["precision"]))
+        if found_full_version:
+            return cls(int(found_full_version["precision"]))
+
+        return None
 
 
 @dataclass(frozen=True)

--- a/tests/unit/decodable/client/test_types.py
+++ b/tests/unit/decodable/client/test_types.py
@@ -31,6 +31,9 @@ class TestTypes:
         t = types.Timestamp.from_str("TIMESTAMP(15) WITH TIME ZONE")
         assert t == types.Timestamp(precision=15, timezone=True)
 
+        t = types.TimestampLocal.from_str("TIMESTAMP(3) WITH LOCAL TIME ZONE")
+        assert t == types.TimestampLocal(precision=3)
+
     def test_from_str_dispatch(self):
         str_types = ["DECIMAL", "STRING", "ARRAY<CHAR(1)>", "VARBINAR", "TIMESTAMP(3)"]
 


### PR DESCRIPTION
Resolves https://github.com/decodableco/dbt-decodable/issues/7

@gunnarmorling The query works with this fix, but the resulting precision is always 3, no matter which integer I enter in `to_timestamp_ltz(ts_ms, 3)`. I assume that's not the way it should work?
cc @rmetzger 

edit: This does not appear to be an issue of this dbt adapter. The test currently uses precision 3, but it does work with other precision as well. I am not sure where the specified precision gets lost