### PR TITLE
Issue 33: Migrate stream clear to the data plane

### DIFF
--- a/dbt/adapters/decodable/impl.py
+++ b/dbt/adapters/decodable/impl.py
@@ -243,15 +243,17 @@ class DecodableAdapter(BaseAdapter):
         if not relation.identifier:
             raise_compiler_error("Cannot truncate an unnamed relation")
 
-        client = self._control_plane_client()
-        stream_id = client.get_stream_id(relation.render())
+        control_plane_client = self._control_plane_client()
+        data_plane_client = self._data_plane_client()
+        stream_id = control_plane_client.get_stream_id(relation.render())
 
         if not stream_id:
             raise_database_error(
                 f"Error clearing stream `{relation.render()}`: stream doesn't exist"
             )
 
-        client.clear_stream(stream_id)
+        clear_token_response = control_plane_client.get_clear_stream_token(stream_id)
+        data_plane_client.clear_stream(stream_id, clear_token_response.token)
 
     @available.parse_none
     def rename_relation(self, from_relation: BaseRelation, to_relation: BaseRelation) -> None:

--- a/dbt/adapters/decodable/impl.py
+++ b/dbt/adapters/decodable/impl.py
@@ -39,7 +39,11 @@ from dbt.adapters.decodable.connections import (
 )
 from dbt.adapters.decodable.handler import DecodableHandler
 from dbt.adapters.decodable.relation import DecodableRelation
-from decodable.client.client import DecodableControlPlaneApiClient, SchemaField, DecodableDataPlaneApiClient
+from decodable.client.client import (
+    DecodableControlPlaneApiClient,
+    SchemaField,
+    DecodableDataPlaneApiClient,
+)
 from decodable.client.types import (
     FieldType,
     PrimaryKey,
@@ -369,7 +373,9 @@ class DecodableAdapter(BaseAdapter):
         if not relation.identifier:
             return []
 
-        stream_info = self._control_plane_client().get_stream_information(stream_id=relation.render())
+        stream_info = self._control_plane_client().get_stream_information(
+            stream_id=relation.render()
+        )
 
         for schema_column in stream_info["schema"]:
             columns.append(
@@ -654,9 +660,7 @@ class DecodableAdapter(BaseAdapter):
         return handle.control_plane_client
 
     def _data_plane_client(self) -> DecodableDataPlaneApiClient:
-        handle: DecodableHandler = (
-            self.get_thread_connection().handle
-        )
+        handle: DecodableHandler = self.get_thread_connection().handle
         return handle.data_plane_client
 
     @classmethod

--- a/dbt/adapters/decodable/impl.py
+++ b/dbt/adapters/decodable/impl.py
@@ -660,7 +660,9 @@ class DecodableAdapter(BaseAdapter):
         return handle.control_plane_client
 
     def _data_plane_client(self) -> DecodableDataPlaneApiClient:
-        handle: DecodableHandler = self.get_thread_connection().handle
+        handle: DecodableHandler = (
+            self.get_thread_connection().handle
+        )  # pyright: ignore [reportGeneralTypeIssues]
         return handle.data_plane_client
 
     @classmethod

--- a/decodable/client/client.py
+++ b/decodable/client/client.py
@@ -106,7 +106,9 @@ class DataPlaneTokenResponse:
     def from_dict(cls, response: Dict[str, Any]) -> DataPlaneTokenResponse:
         return cls(
             # Some requests don't include a body, so check whether it's present
-            data_plane_request=response["data_plane_request"] if "data_plane_request" in response else None,
+            data_plane_request=response["data_plane_request"]
+            if "data_plane_request" in response
+            else None,
             token=response["token"],
         )
 
@@ -185,8 +187,7 @@ class DecodableDataPlaneApiClient:
 
     def clear_stream(self, stream_id: str, token: str) -> None:
         self._post_api_request(
-            bearer_token=token,
-            endpoint_url=f"{self.config.api_url}/streams/{stream_id}/clear"
+            bearer_token=token, endpoint_url=f"{self.config.api_url}/streams/{stream_id}/clear"
         )
 
     def _get_api_request(
@@ -314,7 +315,7 @@ class DecodableControlPlaneApiClient:
     def get_clear_stream_token(self, stream_id: str) -> DataPlaneTokenResponse:
         response = self._post_api_request(
             payload={},
-            endpoint_url=f"{self.config.decodable_api_url()}/streams/{stream_id}/clear/token"
+            endpoint_url=f"{self.config.decodable_api_url()}/streams/{stream_id}/clear/token",
         )
         return DataPlaneTokenResponse.from_dict(response.json())
 

--- a/decodable/client/client.py
+++ b/decodable/client/client.py
@@ -99,7 +99,7 @@ class PreviewTokensResponse:
 
 @dataclass
 class DataPlaneTokenResponse:
-    data_plane_request: str
+    data_plane_request: Optional[str]
     token: str
 
     @classmethod

--- a/decodable/client/client.py
+++ b/decodable/client/client.py
@@ -97,6 +97,20 @@ class PreviewTokensResponse:
         )
 
 
+@dataclass
+class DataPlaneTokenResponse:
+    data_plane_request: str
+    token: str
+
+    @classmethod
+    def from_dict(cls, response: Dict[str, Any]) -> DataPlaneTokenResponse:
+        return cls(
+            # Some requests don't include a body, so check whether it's present
+            data_plane_request=response["data_plane_request"] if "data_plane_request" in response else None,
+            token=response["token"],
+        )
+
+
 class DecodableAPIException(Exception):
     @classmethod
     def category(cls) -> str:
@@ -168,6 +182,12 @@ class DecodableDataPlaneApiClient:
             additional_headers={"decodable-token": next_token},
         )
         return PreviewResponse.from_dict(response.json())
+
+    def clear_stream(self, stream_id: str, token: str) -> None:
+        self._post_api_request(
+            bearer_token=token,
+            endpoint_url=f"{self.config.api_url}/streams/{stream_id}/clear"
+        )
 
     def _get_api_request(
         self,
@@ -291,10 +311,12 @@ class DecodableControlPlaneApiClient:
             endpoint_url=f"{self.config.decodable_api_url()}/streams/{stream_id}"
         )
 
-    def clear_stream(self, stream_id: str) -> None:
-        self._post_api_request(
-            payload={}, endpoint_url=f"{self.config.decodable_api_url()}/streams/{stream_id}/clear"
+    def get_clear_stream_token(self, stream_id: str) -> DataPlaneTokenResponse:
+        response = self._post_api_request(
+            payload={},
+            endpoint_url=f"{self.config.decodable_api_url()}/streams/{stream_id}/clear/token"
         )
+        return DataPlaneTokenResponse.from_dict(response.json())
 
     def list_pipelines(self) -> ApiResponse:
         response = self._get_api_request(


### PR DESCRIPTION
Resolves https://github.com/decodableco/dbt-decodable/issues/33

As described in the issue, the only usage of stream clear I could track down was when running `dbt seed` and the stream+connection exist already. 

I checked that with this change, a token is obtained and the stream clear request is sent to the data plane. See [this comment](https://github.com/decodableco/dbt-decodable/issues/33#issuecomment-1890989055) for instructions on how to reproduce.