### PR TITLE
Set version to 2.0.0rc1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dbt-decodable"
-version = "1.3.2"
+version = "2.0.0rc1"
 description = "The Decodable adapter plugin for DBT"
 license = "Apache2.0"
 authors = [


### PR DESCRIPTION
This will enable us to publish a release candidate for version 2.

The major version bump is due to backward incompatibility introduced by the move to schema v2.

There are other changes we'll be making in the interest of feature parity with out other clients, which may bring other breaking changes with them. Likewise we're upgrading the DBT version, which changes the python version requirements. So we're publishing release candidates for now until we're sure the interface is stable again.

I've followed the pre-release versioning guidance from https://peps.python.org/pep-0440/#pre-releases to come up with the new version string.

If this looks good, I'll merge & go about publishing the release per the README.