### PR TITLE
DE-8600: DBT support for all pipeline & output stream configurations

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -109,7 +109,7 @@ jobs:
         run: |
           poetry run twine check dist/*
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/
@@ -152,7 +152,7 @@ jobs:
           persist-credentials: false
 
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/
@@ -179,7 +179,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist/

--- a/dbt/adapters/decodable/connections.py
+++ b/dbt/adapters/decodable/connections.py
@@ -28,7 +28,7 @@ from dbt.events import AdapterLogger
 from dbt.exceptions import RuntimeException
 
 from dbt.adapters.decodable.handler import DecodableCursor, DecodableHandler
-from decodable.client.api import StartPosition
+from decodable.client.api import StartPositionTag
 from decodable.client.client_factory import DecodableClientFactory
 
 
@@ -42,7 +42,7 @@ class DecodableAdapterCredentials(Credentials):
     profile_name: str
     account_name: str
     materialize_tests: bool = False
-    preview_start: StartPosition = StartPosition.EARLIEST
+    preview_start: StartPositionTag = StartPositionTag.EARLIEST
     request_timeout_ms: int = 60000
     local_namespace: Optional[str] = None
 

--- a/dbt/adapters/decodable/handler.py
+++ b/dbt/adapters/decodable/handler.py
@@ -19,8 +19,11 @@ from typing import Any, Dict, Iterator, List, Optional, Sequence, Tuple
 
 from dbt.events import AdapterLogger
 
-from decodable.client.api import StartPosition
-from decodable.client.client import DecodableControlPlaneApiClient, DecodableDataPlaneApiClient
+from decodable.client.api import StartPositionTag
+from decodable.client.client import (
+    DecodableControlPlaneApiClient,
+    DecodableDataPlaneApiClient,
+)
 
 
 def exponential_backoff(timeout: float) -> Iterator[float]:
@@ -46,7 +49,7 @@ class DecodableCursor:
         self,
         control_plane_client: DecodableControlPlaneApiClient,
         data_plane_client: DecodableDataPlaneApiClient,
-        preview_start: StartPosition,
+        preview_start: StartPositionTag,
         timeout: float,
     ):
         self.logger.debug(
@@ -130,7 +133,7 @@ class DecodableHandler:
         self,
         control_plane_client: DecodableControlPlaneApiClient,
         data_plane_client: DecodableDataPlaneApiClient,
-        preview_start: StartPosition,
+        preview_start: StartPositionTag,
         timeout: float,
     ):
         self.control_plane_client = control_plane_client
@@ -140,5 +143,8 @@ class DecodableHandler:
 
     def cursor(self) -> DecodableCursor:
         return DecodableCursor(
-            self.control_plane_client, self.data_plane_client, self.preview_start, self.timeout
+            self.control_plane_client,
+            self.data_plane_client,
+            self.preview_start,
+            self.timeout,
         )

--- a/dbt/include/decodable/macros/materializations/table/create_table_as.sql
+++ b/dbt/include/decodable/macros/materializations/table/create_table_as.sql
@@ -15,7 +15,7 @@
  */
 
 {% macro decodable__create_table_as(temporary, relation, sql) -%}
-  {% set watermarks = config.get('watermarks', []) %}
-  {% set primary_key = config.get('primary_key', []) %}
-  {% do adapter.create_table(sql, temporary, relation, graph.nodes, watermarks, primary_key) %}
+  {% set output_stream = config.get('output_stream', {}) %}
+  {% set pipeline = config.get('pipeline', {}) %}
+  {% do adapter.create_table(sql, temporary, relation, graph.nodes, pipeline, output_stream) %}
 {%- endmacro %}

--- a/dbt/include/decodable/macros/materializations/table/table.sql
+++ b/dbt/include/decodable/macros/materializations/table/table.sql
@@ -28,9 +28,9 @@
 
   {% set should_create = {'value': false} %}
   {% if existing_relation is not none %}
-    {% set watermarks = config.get('watermarks', []) %}
-    {% set primary_key = config.get('primary_key', []) %}
-    {% if adapter.has_changed(sql, target_relation, watermarks, primary_key) or should_full_refresh() %}
+    {% set output_stream = config.get('output_stream', {}) %}
+    {% set pipeline = config.get('pipeline', {}) %}
+    {% if adapter.has_changed(sql, target_relation, pipeline, output_stream) or should_full_refresh() %}
       {{ adapter.drop_relation(existing_relation) }}
       {% do should_create.update({'value': true}) %}
     {% endif %}

--- a/dbt/include/decodable/macros/operations.sql
+++ b/dbt/include/decodable/macros/operations.sql
@@ -1,5 +1,5 @@
 /*
- *  Copyright 2023 decodable Inc.
+ *  Copyright 2025 decodable Inc.
  *
  *  Licensed under the Apache License, Version 2.0 (the "License");
  *  you may not use this file except in compliance with the License.

--- a/decodable/client/api.py
+++ b/decodable/client/api.py
@@ -15,11 +15,24 @@
 #
 
 from enum import Enum
+from typing import Union, Dict
+from dataclasses import dataclass
 
 
-class StartPosition(Enum):
+class StartPositionTag(Enum):
     EARLIEST = "earliest"
     LATEST = "latest"
+
+
+@dataclass
+class StartPosition:
+    type: str
+    value: str
+
+
+StreamStartPositions = Dict[str, Dict[str, str]]
+
+StartPositionSpec = Union[StartPositionTag, StartPosition, StreamStartPositions]
 
 
 class Connector(Enum):

--- a/decodable/client/client.py
+++ b/decodable/client/client.py
@@ -15,13 +15,22 @@
 #
 from __future__ import annotations
 
+from dbt.events import AdapterLogger
+
 from dataclasses import dataclass
 from typing import Any, Dict, Optional, List
+
+from yaml import dump_all, full_load_all
 
 import requests
 from typing_extensions import override
 
-from decodable.client.api import Connector, ConnectionType, StartPosition
+from decodable.client.api import (
+    Connector,
+    ConnectionType,
+    StreamStartPositions,
+    StartPositionTag,
+)
 from decodable.config.client_config import (
     DecodableControlPlaneClientConfig,
     DecodableDataPlaneClientConfig,
@@ -176,7 +185,8 @@ class DecodableDataPlaneApiClient:
 
     def clear_stream(self, stream_id: str, token: str) -> None:
         self._post_api_request(
-            bearer_token=token, endpoint_url=f"{self.config.api_url}/streams/{stream_id}/clear"
+            bearer_token=token,
+            endpoint_url=f"{self.config.api_url}/streams/{stream_id}/clear",
         )
 
     def _get_api_request(
@@ -203,7 +213,11 @@ class DecodableDataPlaneApiClient:
             raise_api_exception(response.status_code, response.json())
 
     def _post_api_request(
-        self, bearer_token: str, endpoint_url: str, payload: Any = None, data: Any = None
+        self,
+        bearer_token: str,
+        endpoint_url: str,
+        payload: Any = None,
+        data: Any = None,
     ) -> requests.Response:
         response = requests.post(
             url=endpoint_url,
@@ -223,6 +237,8 @@ class DecodableDataPlaneApiClient:
 
 
 class DecodableControlPlaneApiClient:
+    logger = AdapterLogger("Decodable")
+
     config: DecodableControlPlaneClientConfig
 
     _schema_v2_request_params: dict[str, str] = {"response_schema_v": "v2"}
@@ -271,6 +287,7 @@ class DecodableControlPlaneApiClient:
             return response.json()
         else:
             raise_api_exception(response.status_code, response.json())
+            assert False, "unreachable"
 
     def get_stream_from_sql(self, sql: str) -> Dict[str, Any]:
         return self._post_api_request(
@@ -336,6 +353,7 @@ class DecodableControlPlaneApiClient:
             return response.json()
         else:
             raise_api_exception(response.status_code, response.json())
+            assert False, "unreachable"
 
     def get_associated_streams(self, pipeline_id: str) -> ApiResponse:
         response = self._get_api_request(
@@ -360,9 +378,11 @@ class DecodableControlPlaneApiClient:
             endpoint_url=f"{self.config.decodable_api_url()}/pipelines/{pipeline_id}",
         ).json()
 
-    def activate_pipeline(self, pipeline_id: str) -> Dict[str, Any]:
+    def activate_pipeline(
+        self, pipeline_id: str, start_positions: StreamStartPositions = dict()
+    ) -> Dict[str, Any]:
         return self._post_api_request(
-            payload={},
+            payload={"start_positions": start_positions},
             endpoint_url=f"{self.config.decodable_api_url()}/pipelines/{pipeline_id}/activate",
         ).json()
 
@@ -380,7 +400,7 @@ class DecodableControlPlaneApiClient:
     def get_preview_tokens(
         self,
         sql: str,
-        preview_start: StartPosition = StartPosition.LATEST,
+        preview_start: StartPositionTag = StartPositionTag.LATEST,
         input_streams: Optional[List[str]] = None,
     ) -> PreviewTokensResponse:
         if input_streams is None:
@@ -392,15 +412,22 @@ class DecodableControlPlaneApiClient:
             },
         }
         response = self._post_api_request(
-            payload=payload, endpoint_url=f"{self.config.decodable_api_url()}/preview/tokens"
+            payload=payload,
+            endpoint_url=f"{self.config.decodable_api_url()}/preview/tokens",
         )
         return PreviewTokensResponse.from_dict(response.json())
+
+    def get_pipeline_dependencies(self, pipeline_id: str) -> Dict[str, Any]:
+        return self._get_api_request(
+            endpoint_url=f"{self.config.decodable_api_url()}/pipelines/{pipeline_id}/dependencies"
+        ).json()
 
     def get_preview_dependencies(self, sql: str) -> Dict[str, Any]:
         payload = {"sql": sql}
 
         return self._post_api_request(
-            payload=payload, endpoint_url=f"{self.config.decodable_api_url()}/preview/dependencies"
+            payload=payload,
+            endpoint_url=f"{self.config.decodable_api_url()}/preview/dependencies",
         ).json()
 
     def list_connections(self) -> ApiResponse:
@@ -480,11 +507,35 @@ class DecodableControlPlaneApiClient:
 
         return AccountInfoResponse.from_dict(response.json())
 
+    def apply(
+        self, resources: List[Dict[str, Any]], dry_run: bool = False
+    ) -> List[Dict[str, Any]]:
+        payload = dump_all(resources)
+
+        response = requests.post(
+            url=f"{self.config.decodable_api_url()}/apply?dry_run={str(dry_run).lower()}",
+            data=payload,
+            headers={
+                "accept": "application/x-yaml",
+                "content-type": "application/x-yaml",
+                "authorization": f"Bearer {self.config.access_token}",
+            },
+        )
+
+        if response.ok:
+            return list(full_load_all(response.content))
+        else:
+            raise_api_exception(response.status_code, response.json())
+            assert False, "unreachable"
+
     def _parse_response(self, result: Any) -> ApiResponse:
         return ApiResponse(items=result["items"], next_page_token=result["next_page_token"])
 
     def _post_api_request(
-        self, payload: Any, endpoint_url: str, params: dict[str, str] | None = None
+        self,
+        payload: Any,
+        endpoint_url: str,
+        params: dict[str, str] | None = None,
     ) -> requests.Response:
         response = requests.post(
             url=endpoint_url,
@@ -501,6 +552,7 @@ class DecodableControlPlaneApiClient:
             return response
         else:
             raise_api_exception(response.status_code, response.json())
+            assert False, "unreachable"
 
     def _patch_api_request(self, payload: Any, endpoint_url: str) -> requests.Response:
         response = requests.patch(

--- a/decodable/client/client_factory.py
+++ b/decodable/client/client_factory.py
@@ -15,7 +15,10 @@
 #
 from typing import Optional
 
-from decodable.client.client import DecodableControlPlaneApiClient, DecodableDataPlaneApiClient
+from decodable.client.client import (
+    DecodableControlPlaneApiClient,
+    DecodableDataPlaneApiClient,
+)
 from decodable.config.client_config import (
     DecodableControlPlaneClientConfig,
     DecodableDataPlaneClientConfig,
@@ -40,7 +43,9 @@ class DecodableClientFactory:
         access_token = profile_access_tokens.profile_tokens[profile_name]
         return DecodableControlPlaneApiClient(
             config=DecodableControlPlaneClientConfig(
-                access_token=access_token, account_name=decodable_account_name, api_url=api_url
+                access_token=access_token,
+                account_name=decodable_account_name,
+                api_url=api_url,
             )
         )
 

--- a/decodable/client/schema.py
+++ b/decodable/client/schema.py
@@ -17,7 +17,12 @@
 
 import json
 
-from dataclasses import dataclass, asdict, field as dataclass_field, fields as dataclass_fields
+from dataclasses import (
+    dataclass,
+    asdict,
+    field as dataclass_field,
+    fields as dataclass_fields,
+)
 from decodable.client.types import FieldType
 from typing import Any, Sequence, List, Dict
 
@@ -40,7 +45,9 @@ class SchemaField:
         field_type = FieldType.from_str(type_)
         if field_type is None:
             raise_compiler_error(f"Type '{type_}' not recognized")
-        return field_type
+            assert False, "unreachable"
+        else:
+            return field_type
 
     def to_dict(self) -> Dict[str, str]:
         res = {}
@@ -117,28 +124,15 @@ class SchemaV2:
     constraints: Constraints
 
     @classmethod
-    def from_json_components(
-        cls,
-        fields: List[Dict[str, str]],
-        watermarks: List[Dict[str, str]],
-        primary_key: List[str],
-    ) -> "SchemaV2":
-        return SchemaV2(
-            fields=[schema_field_factory(field) for field in fields],
-            watermarks=[
-                Watermark(name=w_json["name"], expression=w_json["expression"])
-                for w_json in watermarks
-            ],
-            constraints=Constraints(primary_key=primary_key),
-        )
-
-    @classmethod
     def from_json(cls, json: Dict[str, Any]) -> "SchemaV2":
         primary_key: List[str] = json.get("constraints", {}).get("primary_key", [])
-        return cls.from_json_components(
-            json["fields"],
-            json.get("watermarks", []),
-            primary_key,
+        return SchemaV2(
+            fields=[schema_field_factory(field) for field in json.get("fields", [])],
+            watermarks=[
+                Watermark(name=w_json["name"], expression=w_json["expression"])
+                for w_json in json.get("watermarks", [])
+            ],
+            constraints=Constraints(primary_key=primary_key),
         )
 
     def to_dict(self) -> Dict[str, Any]:

--- a/decodable/config/profile_reader.py
+++ b/decodable/config/profile_reader.py
@@ -26,7 +26,9 @@ PROFILE_ENV_VARIABLE_NAME = "DECODABLE_PROFILE"
 
 class DecodableProfileReader:
     @staticmethod
-    def load_profiles(default_profile_path: str = DEFAULT_PROFILE_PATH) -> DecodableAccessTokens:
+    def load_profiles(
+        default_profile_path: str = DEFAULT_PROFILE_PATH,
+    ) -> DecodableAccessTokens:
         profiles_path = Path(default_profile_path)
         if profiles_path.is_file() is False:
             raise Exception(

--- a/example_project/example/models/example/events_count.sql
+++ b/example_project/example/models/example/events_count.sql
@@ -1,21 +1,25 @@
 {{
     config(
-        primary_key=["resource_type", "audit_event_type"],
-        watermarks=[
-            {
-                "name": "min_timestamp",
-                "expression": "min_timestamp - interval '0.100' second"
+        output_stream={
+            "schema_v2": {
+                "watermarks": [
+                    {
+                        "name": "min_timestamp",
+                        "expression": "min_timestamp - interval '0.100' SECOND"
+                    }
+                ],
+                "constraints": {
+                    "primary_key": ["resource_type", "audit_event_type"],
+                }
             }
-
-        ]
+        },
     )
 }}
-
 select
     coalesce(resource_type, '__UNKNOWN__') as resource_type,
     coalesce(audit_event_type, '__UNKNOWN__') as audit_event_type,
     count(1) as count_observed,
     min(to_timestamp_ltz(`timestamp`, 3)) as min_timestamp,
     max(to_timestamp_ltz(`timestamp`, 3)) as max_timestamp
-from _events
+from (select * from _events)
 group by resource_type, audit_event_type

--- a/example_project/example/models/example/http_events.sql
+++ b/example_project/example/models/example/http_events.sql
@@ -1,12 +1,21 @@
 /* Example following the quickstart guide at https://docs.decodable.co/docs/quickstart-guide */
 {{
     config(
-        watermarks=[
-            {
-                "name": "timestamp",
-                "expression": "`timestamp` - INTERVAL '0.001' SECOND"
+        output_stream={
+            "schema_v2": {
+                "watermarks": [
+                    {
+                        "name": "timestamp",
+                        "expression": "`timestamp` - INTERVAL '0.001' SECOND"
+                    }
+                ],
             }
-        ]
+        },
+        pipeline={
+            "execution": {
+                "initial_start_positions": { "envoy_raw": "earliest" }
+            }
+        }
     )
 }}
 

--- a/example_project/example/models/example/http_events_bytes_sent.sql
+++ b/example_project/example/models/example/http_events_bytes_sent.sql
@@ -1,4 +1,14 @@
-{{ config(primary_key=["method"]) }}
+{{
+    config(
+        output_stream={
+            "schema_v2": {
+                "constraints": {
+                  "primary_key": ["method"]
+                }
+            }
+        }
+    )
+}}
 
 SELECT coalesce(CAST(envoy['method'] AS STRING), '__UNKNOWN__')  AS `method`,
        SUM(CAST(envoy['bytes_sent'] AS INT)) AS `total_bytes_sent`

--- a/example_project/example/models/example/schema.yml
+++ b/example_project/example/models/example/schema.yml
@@ -1,4 +1,3 @@
-
 version: 2
 
 models:

--- a/tests/functional/adapter/simple/test_simple_project.py
+++ b/tests/functional/adapter/simple/test_simple_project.py
@@ -16,7 +16,9 @@
 
 from typing import Any, List
 import pytest
-from dbt.tests.util import run_dbt  # pyright: ignore [reportMissingImports]
+from dbt.tests.util import (  # pyright: ignore
+    run_dbt,
+)
 
 from fixtures import (
     my_seed_csv,

--- a/tests/unit/decodable/client/test_schema.py
+++ b/tests/unit/decodable/client/test_schema.py
@@ -83,17 +83,6 @@ class TestComputedSchemaField(unittest.TestCase):
 
 
 class TestSchemaV2(unittest.TestCase):
-    def test_from_json_components(self):
-        fields = [{"name": "field1", "kind": "physical", "type": "STRING"}]
-        watermarks = [{"name": "wm1", "expression": "expr1"}]
-        primary_key = ["field1"]
-        schema = SchemaV2.from_json_components(fields, watermarks, primary_key)
-        self.assertEqual(len(schema.fields), 1)
-        self.assertEqual(schema.fields[0].name, "field1")
-        self.assertEqual(len(schema.watermarks), 1)
-        self.assertEqual(schema.watermarks[0].name, "wm1")
-        self.assertEqual(schema.constraints.primary_key, primary_key)
-
     def test_from_json(self):
         json_data = {
             "fields": [{"name": "field1", "kind": "physical", "type": "STRING"}],
@@ -154,7 +143,12 @@ class TestSchemaFieldFactory(unittest.TestCase):
         self.assertEqual(field.kind, FieldKind.physical)
 
     def test_schema_field_factory_metadata(self):
-        field_dict = {"name": "field1", "kind": "metadata", "key": "key1", "type": "STRING"}
+        field_dict = {
+            "name": "field1",
+            "kind": "metadata",
+            "key": "key1",
+            "type": "STRING",
+        }
         field = schema_field_factory(field_dict)
         assert type(field) is MetadataSchemaField
         self.assertEqual(field.name, "field1")

--- a/tests/unit/decodable/config/test_profile_reader.py
+++ b/tests/unit/decodable/config/test_profile_reader.py
@@ -16,7 +16,10 @@
 import os
 from unittest import mock
 from decodable.config.profile import DecodableAccessTokens
-from decodable.config.profile_reader import DecodableProfileReader, PROFILE_ENV_VARIABLE_NAME
+from decodable.config.profile_reader import (
+    DecodableProfileReader,
+    PROFILE_ENV_VARIABLE_NAME,
+)
 
 TEST_PROFILE_NAME = "default"
 TEST_PROFILE_ACCESS_TOKEN = "yyy"


### PR DESCRIPTION
_This is a new, squashed, PR for the [draft](https://github.com/decodableco/dbt-decodable/pull/44) that was opened a few weeks ago. The draft was a mess with my Python skill issues._

The general idea of this PR is to change the config schema to take a partial [Decodable Resource Spec](https://docs.decodable.co/declarative/definitions.html) for each of these objects, rather than just accepting some subset of those specs directly.

The partial spec from the config is then merged with the bits that DBT usually infers, such as the fields (inferred from the SQL), the names, etc.

Then this _complete_ spec is sent to our new `/apply` endpoint. This endpoint has a lot of improvements over our older APIs, and has exclusive access to some newer features. It also avoids the requirement of stopping jobs manually before applying updates, which simplifies the adapter code a bit, and sometimes makes for a better UX.

See the [http_events example](https://github.com/decodableco/dbt-decodable/pull/44/files#diff-d8460ff458da6c6db5679e4d02b219430d5a42990668d8894ece6cb0d9f7d8edR4) to get an idea of how this would change the interface.

**Note on the approach:** My hope is to move the DBT adapter to being a somewhat simple layer on top of our Declarative API features. A consequence of this is that you'll see me handling the resoource specs as basically just YAML (or the python Dict representation of that YAML). This would let us add fields to the API, and have them picked up by DBT automatically without publishing a new version. The current code is _not_ agnostic to the spec versions, so picking up new versions of our resource spec would require a new adapter version. My gut feeling was that this is a decent compromise of flexibility & convenience, but I'd love to hear from others.

We've also discussed spitting out Decodable Declarative Resource YAML from the dbt compile step. With this done, I think that amounts to basically spitting out the spec we build from this configuration. There may be some "details", but this work should serve both.

## Evidence of working examples

Here's a run of the examples after this change. There's not real change to the output, but at least you can see they work. I've also tested making changes to the example configurations and ensured that the right resources are recreated as expected.

```
❯ DECODABLE_PROFILE=jbreeden dbt run
15:55:07  Running with dbt=1.3.2
15:55:07  Found 3 models, 0 tests, 0 snapshots, 0 analyses, 273 macros, 0 operations, 1 seed file, 0 sources, 0 exposures, 0 metrics
15:55:07
15:55:08  Concurrency: 1 threads (target='dev')
15:55:08
15:55:08  1 of 3 START sql table model dbt__events_count ................................. [RUN]
15:55:09  1 of 3 OK created sql table model dbt__events_count ............................ [OK in 1.26s]
15:55:09  2 of 3 START sql table model dbt__http_events .................................. [RUN]
15:55:10  2 of 3 OK created sql table model dbt__http_events ............................. [OK in 1.32s]
15:55:10  3 of 3 START sql table model dbt__http_events_bytes_sent ....................... [RUN]
15:55:12  3 of 3 OK created sql table model dbt__http_events_bytes_sent .................. [OK in 1.24s]
15:55:12
15:55:12  Finished running 3 table models in 0 hours 0 minutes and 4.45 seconds (4.45s).
15:55:12
15:55:12  Completed successfully
15:55:12
15:55:12  Done. PASS=3 WARN=0 ERROR=0 SKIP=0 TOTAL=3
```